### PR TITLE
Snapshot-friendly

### DIFF
--- a/src/camera-plus.common.ts
+++ b/src/camera-plus.common.ts
@@ -25,7 +25,7 @@ export abstract class CameraPlusBase extends ContentView
   public set debug(value: boolean) {
     CameraUtil.debug = value;
   }
-  public events: ICameraPlusEvents;
+  public events: any /*ICameraPlusEvents*/;
 
   /**
    * Video Support (off by default)

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -20,7 +20,8 @@
         "noImplicitAny": false,
         "noImplicitReturns": true,
         "noImplicitUseStrict": false,
-        "noFallthroughCasesInSwitch": true
+        "noFallthroughCasesInSwitch": true,
+        "skipLibCheck": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Changes to allow this plugin to be used with android webpack/snapshot.

Java package/namespace usage evaluated at build time will cause snapshot to fail so must be placed in a function that will not execute until runtime.

Some additional changes to satisfy TS compilation.