### PR TITLE
fix(android): CamcorderProfile.get has 2 overrides

### DIFF
--- a/src/camera-plus.android.ts
+++ b/src/camera-plus.android.ts
@@ -376,7 +376,7 @@ export class CameraPlus extends CameraPlusBase {
     this._mediaRecorder.setAudioSource(android.media.MediaRecorder.AudioSource.CAMCORDER);
     this._mediaRecorder.setVideoSource(android.media.MediaRecorder.VideoSource.CAMERA);
     // Step 3: Set a CamcorderProfile (requires API Level 8 or higher)
-    this._mediaRecorder.setProfile(android.media.CamcorderProfile.get(android.media.CamcorderProfile.QUALITY_HIGH));
+    this._mediaRecorder.setProfile(android.media.CamcorderProfile.get(this.cameraId, android.media.CamcorderProfile.QUALITY_HIGH));
     // Step 4: Set output file
     const videoPath = this._getOutputMediaFile(2).toString();
     this._videoPath = videoPath;


### PR DESCRIPTION
https://developer.android.com/reference/android/media/CamcorderProfile#get

CamcorderProfile.get has 2 overrides, the single parameter signature defaults to back camera, but the 2 parameter version allows other cameras. This was likely the reason ReactionRecorder was not working on many devices for PNP (such as Nexus), it probably worked on many high end devices where there profiles for front and back camera were mostly compatible, but failed for some others. Even in cases where it didn't fail, could have been the cause of some quirky behaviour.