### PR TITLE
Added events for the confirm dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,15 @@ _Note: These properties need set before the initialization of the camera. Users 
 
 | Name                    | Description                                                        |
 | ----------------------- | ------------------------------------------------------------------ |
-| **errorEvent**          | Executes when an error is emitted from CameraPlu                   |
+| **errorEvent**          | Executes when an error is emitted from CameraPlus                   |
 | **photoCapturedEvent**  | Executes when a photo is taken.                                    |
 | **toggleCameraEvent**   | Executes when the device camera is toggled.                        |
 | **imagesSelectedEvent** | Executes when images are selected from the device library/gallery. |
 | **videoRecordingStartedEvent** | Executes when video starts recording. |
 | **videoRecordingFinishedEvent** | Executes when video stops recording but has not process yet. |
 | **videoRecordingReadyEvent** | Executes when video has completed processing and is ready to be used. |
+| **confirmScreenShownEvent** | Executes when  the picture confirm dialog is shown.. |
+| **confirmScreenDismissedEvent** | Executes when the picture confirm dialog is dismissed either by Retake or Save button. |
 
 
 ## Option Interfaces

--- a/src/camera-plus.android.ts
+++ b/src/camera-plus.android.ts
@@ -1364,6 +1364,7 @@ export class CameraPlus extends CameraPlusBase {
     CLog('nativeFile', nativeFile);
 
     if (saveToGallery === true && confirmPic === true) {
+      this.sendEvent(CameraPlus.confirmScreenShownEvent);
       const result = await CamHelpers.createImageConfirmationDialog(
         data,
         confirmPicRetakeText,
@@ -1371,6 +1372,8 @@ export class CameraPlus extends CameraPlusBase {
       ).catch(ex => {
         CLog('Error createImageConfirmationDialog', ex);
       });
+
+      this.sendEvent(CameraPlus.confirmScreenDismissedEvent);
 
       CLog(`confirmation result = ${result}`);
       if (result !== true) {

--- a/src/camera-plus.common.ts
+++ b/src/camera-plus.common.ts
@@ -75,6 +75,16 @@ export abstract class CameraPlusBase extends ContentView implements CameraPlusDe
   public static videoRecordingReadyEvent = 'videoRecordingReadyEvent';
 
   /**
+   * String value when hooking into the confirmScreenShownEvent. This event fires when the picture confirm dialog is shown.
+   */
+  public static confirmScreenShownEvent = 'confirmScreenShownEvent';
+
+  /**
+   * String value when hooking into the confirmScreenDismissedEvent. This event fires when the picture confirm dialog is dismissed either by Retake or Save button.
+   */
+  public static confirmScreenDismissedEvent = 'confirmScreenDismissedEvent';
+
+  /**
    * If true the default take picture event will present a confirmation dialog. Default is true.
    */
   @GetSetProperty() public confirmPhotos: boolean = true;
@@ -325,6 +335,8 @@ export interface ICameraPlusEvents {
   videoRecordingStartedEvent: any;
   videoRecordingFinishedEvent: any;
   videoRecordingReadyEvent: any;
+  confirmScreenShownEvent: any;
+  confirmScreenDismissedEvent: any;
 }
 
 export interface IVideoOptions {

--- a/src/camera-plus.ios.ts
+++ b/src/camera-plus.ios.ts
@@ -418,6 +418,7 @@ export class MySwifty extends SwiftyCamViewController {
       this._imageConfirmBg.addSubview(retakeBtn);
       this._imageConfirmBg.addSubview(saveBtn);
       this.view.addSubview(this._imageConfirmBg);
+      this._owner.get().sendEvent(CameraPlus.confirmScreenShownEvent);
     } else {
       // no confirmation - just save
       this.savePhoto();
@@ -429,6 +430,7 @@ export class MySwifty extends SwiftyCamViewController {
     if (this._imageConfirmBg) {
       this._imageConfirmBg.removeFromSuperview();
       this._imageConfirmBg = null;
+      this._owner.get().sendEvent(CameraPlus.confirmScreenDismissedEvent);
     }
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,6 +54,16 @@ export declare class CameraPlus extends ContentView {
   public static videoRecordingReadyEvent: string;
 
   /**
+   * String value when hooking into the confirmScreenShownEvent. This event fires when the confirm dialog is shown.
+   */
+  public static confirmScreenShownEvent = 'confirmScreenShownEvent';
+
+  /**
+   * String value when hooking into the confirmScreenDismissedEvent. This event fires when the confirm dialog is dismissed either by Retake or Save.
+   */
+  public static confirmScreenDismissedEvent = 'confirmScreenDismissedEvent';
+
+  /**
    * If true console logs will be output to help debug the Camera Plus events.
    */
   debug: boolean;


### PR DESCRIPTION
This is useful especially on iOS if you want to overlay something on the camera view, because the confirm prompt appears underneath your overlays.