### PR TITLE
Make HEVC configurable

### DIFF
--- a/src/camera-plus.android.ts
+++ b/src/camera-plus.android.ts
@@ -491,7 +491,7 @@ export class CameraPlus extends CameraPlusBase {
     this._mediaRecorder.setOutputFormat(android.media.MediaRecorder.OutputFormat.MPEG_4);
     this._mediaRecorder.setVideoSize(quality.videoFrameWidth, quality.videoFrameHeight);
     this._mediaRecorder.setAudioChannels(quality.audioChannels);
-    const isHevcSupported = android.os.Build.VERSION.SDK_INT >= 24;
+    const isHevcSupported = !options.disableHEVC && android.os.Build.VERSION.SDK_INT >= 24;
     const videoBitRate = isHevcSupported ? quality.videoBitRate / 2 : quality.videoBitRate; // Use half bit rate for hevc
     this._mediaRecorder.setVideoFrameRate(quality.videoFrameRate);
     this._mediaRecorder.setVideoEncodingBitRate(videoBitRate);

--- a/src/camera-plus.common.ts
+++ b/src/camera-plus.common.ts
@@ -375,6 +375,7 @@ export interface IVideoOptions {
   saveToGallery?: boolean;
   height?: number;
   width?: number;
+  disableHEVC?: boolean;
 }
 
 export function GetSetProperty() {

--- a/src/camera-plus.ios.ts
+++ b/src/camera-plus.ios.ts
@@ -401,7 +401,7 @@ export class MySwifty extends SwiftyCamViewController {
             saveToGallery: this._owner.get().saveToGallery
           };
         }
-        if (parseFloat(platform.device.sdkVersion) >= 11) {
+        if (!options.disableHEVC && parseFloat(platform.device.sdkVersion) >= 11) {
           this.videoCodecType = AVVideoCodecTypeHEVC;
         }
         switch (options ? options.quality : CameraVideoQuality.MAX_480P) {


### PR DESCRIPTION
Many devices still don't support HEVC format, which limits the ability
to share HEVC recordings across devices.

IVideoOptions contains an optional property `disableHEVC` (will be
enabled by default), allowing developers to disable HEVC encoding