### PR TITLE
Fix when saveToGallery = false

### DIFF
--- a/src/camera-plus.android.ts
+++ b/src/camera-plus.android.ts
@@ -569,9 +569,10 @@ export class CameraPlus extends CameraPlusBase {
       fileName = `VID_${Date.now()}.mp4`;
       const sdkVersionInt = parseInt(device.sdkVersion);
       if (sdkVersionInt > 21) {
-        const folderPath =
-          android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DCIM).toString() +
-          '/Camera/';
+        const folderPath = utils.ad
+          .getApplicationContext()
+          .getExternalFilesDir(null)
+          .getAbsolutePath();
         if (!fs.Folder.exists(folderPath)) {
           fs.Folder.fromPath(folderPath);
         }
@@ -592,9 +593,10 @@ export class CameraPlus extends CameraPlusBase {
           nativeFile
         );
       } else {
-        const folderPath =
-          android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DCIM).toString() +
-          '/Camera/';
+        const folderPath = utils.ad
+          .getApplicationContext()
+          .getExternalFilesDir(null)
+          .getAbsolutePath();
         if (!fs.Folder.exists(folderPath)) {
           fs.Folder.fromPath(folderPath);
         }

--- a/src/camera-plus.android.ts
+++ b/src/camera-plus.android.ts
@@ -1562,7 +1562,7 @@ export class CameraPlus extends CameraPlusBase {
     CLog('picturePath', picturePath);
     CLog('nativeFile', nativeFile);
 
-    if (saveToGallery === true && confirmPic === true) {
+    if (confirmPic === true) {
       this.sendEvent(CameraPlus.confirmScreenShownEvent);
       const result = await CamHelpers.createImageConfirmationDialog(
         data,
@@ -1580,20 +1580,14 @@ export class CameraPlus extends CameraPlusBase {
       }
 
       // Save image to device gallery
-      this._savePicture(nativeFile, data);
+      this._savePicture(nativeFile, data, saveToGallery === true);
 
       const asset = CamHelpers.assetFromPath(picturePath, reqWidth, reqHeight, shouldKeepAspectRatio);
 
       this.sendEvent(CameraPlus.photoCapturedEvent, asset);
       return;
     } else {
-      if (saveToGallery === true && !confirmPic) {
-        // Save image to device gallery
-        this._savePicture(nativeFile, data);
-        const asset = CamHelpers.assetFromPath(picturePath, reqWidth, reqHeight, shouldKeepAspectRatio);
-        this.sendEvent(CameraPlus.photoCapturedEvent, asset);
-        return;
-      }
+      this._savePicture(nativeFile, data, saveToGallery === true);
 
       const asset = CamHelpers.assetFromPath(picturePath, reqWidth, reqHeight, shouldKeepAspectRatio);
       this.sendEvent(CameraPlus.photoCapturedEvent, asset);
@@ -1601,10 +1595,12 @@ export class CameraPlus extends CameraPlusBase {
     }
   }
 
-  private _savePicture(file, data) {
+  private _savePicture(file, data, broadcastToGallery) {
     try {
       this._saveImageToDisk(file, data);
-      this._addPicToGallery(file);
+      if (broadcastToGallery === true) {
+        this._addPicToGallery(file);
+      }
     } catch (ex) {
       CLog('_savePicture error', ex);
     }


### PR DESCRIPTION
Setting `saveToGallery=false` currently:

1. Does not save images, returns `/storage/emulated/0/Android/data/appid/files/IMG_timestamp.jpg`, but the file does not exist.
2. Saves videos to the DCIM directory.

This PR ensures it's properly saved to `/storage/emulated/0/Android/data/appid/files` in both cases.

Fixes #2