### PR TITLE
feat(android): add aditional encoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,14 @@ export interface IChooseOptions {
 
 ```TS
 export interface IVideoOptions {
+  quality?: CameraVideoQuality;
   confirm?: boolean;
   saveToGallery?: boolean;
   height?: number;
   width?: number;
+  disableHEVC?: boolean;
+  androidMaxVideoBitRate?: number;
+  androidMaxFrameRate?: number;
+  androidMaxAudioBitRate?: number;
 }
 ```

--- a/src/camera-plus.android.ts
+++ b/src/camera-plus.android.ts
@@ -509,10 +509,13 @@ export class CameraPlus extends CameraPlusBase {
     this._mediaRecorder.setVideoSize(quality.videoFrameWidth, quality.videoFrameHeight);
     this._mediaRecorder.setAudioChannels(quality.audioChannels);
     const isHevcSupported = !options.disableHEVC && android.os.Build.VERSION.SDK_INT >= 24;
-    const videoBitRate = isHevcSupported ? quality.videoBitRate / 2 : quality.videoBitRate; // Use half bit rate for hevc
-    this._mediaRecorder.setVideoFrameRate(quality.videoFrameRate);
-    this._mediaRecorder.setVideoEncodingBitRate(videoBitRate);
-    this._mediaRecorder.setAudioEncodingBitRate(quality.audioBitRate);
+    const videoBitRate: number = isHevcSupported ? quality.videoBitRate / 2 : quality.videoBitRate; // Use half bit rate for hevc
+    const maxVideoBitrate = options.androidMaxVideoBitRate ? options.androidMaxVideoBitRate : videoBitRate;
+    const maxVideoFrameRate = options.androidMaxFrameRate ? options.androidMaxFrameRate : quality.videoFrameHeight;
+    const maxAudioBitRate = options.androidMaxAudioBitRate ? options.androidMaxAudioBitRate : quality.audioBitRate;
+    this._mediaRecorder.setVideoFrameRate(Math.min(quality.videoFrameRate, maxVideoFrameRate));
+    this._mediaRecorder.setVideoEncodingBitRate(Math.min(videoBitRate, maxVideoBitrate));
+    this._mediaRecorder.setAudioEncodingBitRate(Math.min(quality.audioBitRate, maxAudioBitRate));
     if (isHevcSupported) {
       this._mediaRecorder.setVideoEncoder((android as any).media.MediaRecorder.VideoEncoder.HEVC);
     } else {

--- a/src/camera-plus.common.ts
+++ b/src/camera-plus.common.ts
@@ -374,6 +374,9 @@ export interface IVideoOptions {
   height?: number;
   width?: number;
   disableHEVC?: boolean;
+  androidMaxVideoBitRate?: number;
+  androidMaxFrameRate?: number;
+  androidMaxAudioBitRate?: number;
 }
 
 export function GetSetProperty() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -267,6 +267,10 @@ export interface IVideoOptions {
   saveToGallery?: boolean;
   height?: number;
   width?: number;
+  disableHEVC?: boolean;
+  androidMaxVideoBitRate?: number;
+  androidMaxFrameRate?: number;
+  androidMaxAudioBitRate?: number;
 }
 
 export interface IChooseOptions {


### PR DESCRIPTION
Adds optional limits to android video/audio BitRate and FrameRate.

Also exposes them in `index.d.ts`.